### PR TITLE
mark fork as deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,19 @@
 [package]
 name = "systemd-journal-logger-memfd-syscall"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Sebastian Wiesner <sebastian@swsnr.de>", "Daniel Estevez <daniel@destevez.net>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/daniestevez/systemd-journal-logger.rs"
 documentation = "https://docs.rs/systemd-journal-logger-memfd-syscall"
-description = "Systemd journal logger for the log facade (fork supporting older glibc versions)"
+description = "Systemd journal logger for the log facade (fork supporting older glibc versions) DEPRECATED"
 categories = ["development-tools::debugging"]
 keywords = ["logging", "systemd", "journal"]
 edition = "2021"
 rust-version = "1.71"
+
+[badges]
+maintenance = { status = "deprecated" }
 
 [dependencies]
 # libsystemd isn't no_std compatible so we can conveniently enable log's std

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# systemd-journal-logger-memfd-syscall
+# systemd-journal-logger-memfd-syscall (deprecated)
 
 A pure Rust [log] logger for the [systemd journal][1] (fork supporting older glibc versions).
 
@@ -6,6 +6,13 @@ A pure Rust [log] logger for the [systemd journal][1] (fork supporting older gli
 [1]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
 
 ## About this fork
+
+**Update:** Since version 2.1.0,
+[systemd-journal-logger is now using rustix](https://github.com/swsnr/systemd-journal-logger.rs/pull/24).
+Rustix uses syscalls instead of calling the libc functions, so
+systemd-journal-logger works again with old glibc versions and there is no need
+to maintain this fork. This fork is now marked as deprecated.
+`systemd-journal-logger >= 2.1` should be used instead.
 
 This crate is a fork of
 [systemd-journal-logger](https://github.com/swsnr/systemd-journal-logger.rs). The


### PR DESCRIPTION
This fork is now deprecated, since the latest version of systemd-journal-logger uses rustix, which calls the memfd_create() syscall directly instead of using the libc function.